### PR TITLE
Modernize extension for TYPO3 v12/13: update TypoScript includes, TCA, FlexForms and metadata

### DIFF
--- a/Configuration/FlexForms/Picture_teaser.xml
+++ b/Configuration/FlexForms/Picture_teaser.xml
@@ -6,26 +6,22 @@
         <type>array</type>
         <el>
             <buttonText>
-                <TCEforms>
-                    <label>Button Text</label>
+                <label>Button Text</label>
                     <config>
                         <type>input</type>
                         <size>30</size>
                         <max>30</max>
                         <eval>trim</eval>
                     </config>
-                </TCEforms>
             </buttonText>
             <buttonLink>
-                <TCEforms>
-                    <label>Button Link</label>
+                <label>Button Link</label>
                     <config>
                         <type>input</type>
                         <size>30</size>
                         <eval>trim</eval>
                         <renderType>inputLink</renderType>
                     </config>
-                </TCEforms>
             </buttonLink>
         </el>
     </ROOT>

--- a/Configuration/FlexForms/Stage.xml
+++ b/Configuration/FlexForms/Stage.xml
@@ -6,26 +6,22 @@
         <type>array</type>
         <el>
             <buttonText>
-                <TCEforms>
-                    <label>Button Text</label>
+                <label>Button Text</label>
                     <config>
                         <type>input</type>
                         <size>30</size>
                         <max>30</max>
                         <eval>trim</eval>
                     </config>
-                </TCEforms>
             </buttonText>
             <buttonLink>
-                <TCEforms>
-                    <label>Button Link</label>
+                <label>Button Link</label>
                     <config>
                         <type>input</type>
                         <size>30</size>
                         <eval>trim</eval>
                         <renderType>inputLink</renderType>
                     </config>
-                </TCEforms>
             </buttonLink>
         </el>
     </ROOT>

--- a/Configuration/PageTSconfig/Base.tsconfig
+++ b/Configuration/PageTSconfig/Base.tsconfig
@@ -80,8 +80,8 @@ mod.wizards.newContentElement.wizardItems.ffpitheme {
   header = Freifunk Pinneberg
 }
 
-<INCLUDE_TYPOSCRIPT: source="DIR:EXT:ffpi_theme/Configuration/PageTSconfig/ContentElements/" extensions="tsconfig">
-<INCLUDE_TYPOSCRIPT: source="DIR:EXT:ffpi_theme/Configuration/PageTSconfig/BackendLayouts/" extensions="tsconfig">
-<INCLUDE_TYPOSCRIPT: source="DIR:EXT:ffpi_theme/Configuration/PageTSconfig/Plugins/" extensions="tsconfig">
+@import "EXT:ffpi_theme/Configuration/PageTSconfig/ContentElements/*.tsconfig"
+@import "EXT:ffpi_theme/Configuration/PageTSconfig/BackendLayouts/*.tsconfig"
+@import "EXT:ffpi_theme/Configuration/PageTSconfig/Plugins/*.tsconfig"
 
-<INCLUDE_TYPOSCRIPT: source="FILE:EXT:ffpi_theme/Configuration/PageTSconfig/RTE.tsconfig">
+@import "EXT:ffpi_theme/Configuration/PageTSconfig/RTE.tsconfig"

--- a/Configuration/Sets/FfpiTheme/config.yaml
+++ b/Configuration/Sets/FfpiTheme/config.yaml
@@ -1,0 +1,2 @@
+name: ffpi/ffpi-theme
+label: 'Freifunk Pinneberg Theme'

--- a/Configuration/Sets/FfpiTheme/constants.typoscript
+++ b/Configuration/Sets/FfpiTheme/constants.typoscript
@@ -1,0 +1,1 @@
+@import '../../TypoScript/constants.typoscript'

--- a/Configuration/Sets/FfpiTheme/page.tsconfig
+++ b/Configuration/Sets/FfpiTheme/page.tsconfig
@@ -1,0 +1,1 @@
+@import '../../page.tsconfig'

--- a/Configuration/Sets/FfpiTheme/setup.typoscript
+++ b/Configuration/Sets/FfpiTheme/setup.typoscript
@@ -1,0 +1,1 @@
+@import '../../TypoScript/setup.typoscript'

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -1,8 +1,6 @@
 <?php
 
-if (!defined('TYPO3_MODE')) {
-    die ('Access denied.');
-}
+defined('TYPO3') || die();
 
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::registerPageTSConfigFile(
@@ -19,9 +17,18 @@ $fields = [
             'type' => 'select',
             'renderType' => 'selectSingle',
             'items' => [
-                ['', ''],
-                ['Question', 'Question.svg'],
-                ['Arrow', 'Arrow.svg'],
+                [
+                    'label' => '',
+                    'value' => '',
+                ],
+                [
+                    'label' => 'Question',
+                    'value' => 'Question.svg',
+                ],
+                [
+                    'label' => 'Arrow',
+                    'value' => 'Arrow.svg',
+                ],
             ],
         ],
     ]

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -1,6 +1,6 @@
 <?php
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 $extensionKey = 'FfpiTheme';
 $extensionPath = 'ffpi_theme';
@@ -13,7 +13,7 @@ $llFrontendDb = 'LLL:EXT:frontend/Resources/Private/Language/Database.xlf:';
 // Add Content Elements from Subfolder
 $files = glob(__DIR__ . '/ContentElements/*.php');
 
-if($files) {
+if ($files) {
     foreach ($files as $file) {
         /** @var array<mixed> $contentElement */
         $contentElement = include $file;
@@ -21,11 +21,12 @@ if($files) {
 
         TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPlugin(
             [
-                $ll . $contentElement['name'] . '.wizard.title',
-                $contentName,
-                $contentElement['icon'] ?? 'EXT:' . $extensionPath . '/ext_icon.svg'
+                'label' => $ll . $contentElement['name'] . '.wizard.title',
+                'value' => $contentName,
+                'icon' => $contentElement['icon'] ?? 'ffpitheme_' . $contentElement['name'],
+                'group' => 'default',
             ],
-            TYPO3\CMS\Extbase\Utility\ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT,
+            'CType',
             $extensionPath
         );
         $GLOBALS['TCA']['tt_content']['types'][$contentName] = [
@@ -34,8 +35,11 @@ if($files) {
         ];
 
         if ($contentElement['flexform']) {
-            $GLOBALS['TCA']['tt_content']['columns']['pi_flexform']['config']['ds'][',' . $contentName] =
-                'FILE:EXT:' . $extensionPath . '/Configuration/FlexForms/' . ucfirst($contentElement['name']) . '.xml';
+            TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue(
+                '*',
+                'FILE:EXT:' . $extensionPath . '/Configuration/FlexForms/' . ucfirst($contentElement['name']) . '.xml',
+                $contentName
+            );
         }
     }
 }

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -1,5 +1,5 @@
-<INCLUDE_TYPOSCRIPT: source="DIR:EXT:ffpi_theme/Configuration/TypoScript/Plugins/" extensions="typoscript">
-<INCLUDE_TYPOSCRIPT: source="DIR:EXT:ffpi_theme/Configuration/TypoScript/Libs/" extensions="typoscript">
-<INCLUDE_TYPOSCRIPT: source="DIR:EXT:ffpi_theme/Configuration/TypoScript/Form/" extensions="typoscript">
-<INCLUDE_TYPOSCRIPT: source="DIR:EXT:ffpi_theme/Configuration/TypoScript/Pages/" extensions="typoscript">
-<INCLUDE_TYPOSCRIPT: source="DIR:EXT:ffpi_theme/Configuration/TypoScript/ContentElements/" extensions="typoscript">
+@import "EXT:ffpi_theme/Configuration/TypoScript/Plugins/*.typoscript"
+@import "EXT:ffpi_theme/Configuration/TypoScript/Libs/*.typoscript"
+@import "EXT:ffpi_theme/Configuration/TypoScript/Form/*.typoscript"
+@import "EXT:ffpi_theme/Configuration/TypoScript/Pages/*.typoscript"
+@import "EXT:ffpi_theme/Configuration/TypoScript/ContentElements/*.typoscript"

--- a/Configuration/page.tsconfig
+++ b/Configuration/page.tsconfig
@@ -1,0 +1,1 @@
+@import 'EXT:ffpi_theme/Configuration/PageTSconfig/Base.tsconfig'

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "ffpi/ffpi-theme",
   "description": "Theme for Freifunk Pinneberg",
   "homepage": "https://pinneberg.freifunk.net",
-  "license": "GPL-3.0",
+  "license": "GPL-3.0-or-later",
   "type": "typo3-cms-extension",
   "authors": [
     {
@@ -20,11 +20,11 @@
     "Theme"
   ],
   "replace": {
-    "ffpi_theme": "self.version",
-    "ffpi/ffpi-theme": "self.version"
+    "typo3-ter/ffpi-theme": "self.version"
   },
   "require": {
-    "typo3/cms-core": "10.0.0 - 11.5.99"
+    "typo3/cms-core": "^12.4 || ^13.4",
+    "typo3/cms-frontend": "^12.4 || ^13.4"
   },
   "suggest": {
     "ffpi/nodecounter": "Displays a Freifunk Nodecounter",
@@ -37,8 +37,7 @@
     }
   },
   "autoload-dev": {
-    "psr-4": {
-    }
+    "psr-4": {}
   },
   "extra": {
     "typo3/cms": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -11,7 +11,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '2.2.1',
     'constraints' => [
         'depends' => [
-            'typo3' => '10.0.0-11.5.99',
+            'typo3' => '12.4.0-13.4.99',
         ],
         'conflicts' => [],
         'suggests' => [

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -1,6 +1,6 @@
 <?php
 
-defined('TYPO3_MODE') or die();
+defined('TYPO3') or die();
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
     'ffpi_theme',


### PR DESCRIPTION
### Motivation
- Bring the extension up to date with TYPO3 v12+/v13+ APIs and conventions and replace deprecated include/registration patterns.

### Description
- Replace legacy TypoScript include directives with `@import` in `Configuration/TypoScript/setup.typoscript` and use `@import` in PageTSconfig includes in `Configuration/PageTSconfig/Base.tsconfig`.
- Modernize FlexForm definitions by removing the deprecated `<TCEforms>` wrapper and moving `label` elements in `Configuration/FlexForms/*` files.
- Update backend PHP wiring to current TYPO3 conventions by changing guard checks to `defined('TYPO3') || die();`, switching plugin registration to use `'CType'` and keyed `label/value/icon/group` arrays, using `
TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue` for flexform registration, and normalizing page TCA item entries to `label`/`value` structures in `Configuration/TCA/Overrides/*.php`.
- Bump package metadata and constraints by updating `composer.json` (`license`, `require`, `replace`) and `ext_emconf.php` (TYPO3 dependency range), and add `Configuration/Sets/FfpiTheme` and `Configuration/page.tsconfig` wrapper files to expose the configuration as a site package set.

### Testing
- No automated tests were added and no automated test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ea94d9964832d9a63c626f4e28f6d)